### PR TITLE
Fix a few legacy issues

### DIFF
--- a/common/src/main/java/info/mmpa/pipeblocker/PipeBlocker.java
+++ b/common/src/main/java/info/mmpa/pipeblocker/PipeBlocker.java
@@ -1,5 +1,6 @@
 package info.mmpa.pipeblocker;
 
+import info.mmpa.pipeblocker.logger.PipeBlockerJavaLogger;
 import info.mmpa.pipeblocker.logger.PipeBlockerLog4jLogger;
 import info.mmpa.pipeblocker.logger.PipeBlockerLogger;
 import info.mmpa.pipeblocker.logger.PipeBlockerStdoutLogger;
@@ -74,13 +75,25 @@ public class PipeBlocker {
         }
     }
 
+    public static void chooseBestLogger() {
+        LOGGER = PipeBlockerLogger.detectLogger();
+    }
+
+    public static void useStdOut() {
+        LOGGER = new PipeBlockerStdoutLogger();
+    }
+
     public static void useLog4j() {
         LOGGER = new PipeBlockerLog4jLogger();
     }
 
+    public static void useJavaLogger() {
+        LOGGER = new PipeBlockerJavaLogger();
+    }
+
     private static void processLine(String line) {
         // ignore blank and comments
-        if(line.length() == 0 || line.charAt(0) == '#')
+        if(line.isEmpty() || line.charAt(0) == '#')
             return;
         if (line.charAt(0) == '@') { // feature
             String feature = line.substring(1);

--- a/common/src/main/java/info/mmpa/pipeblocker/java8/FilterSetter.java
+++ b/common/src/main/java/info/mmpa/pipeblocker/java8/FilterSetter.java
@@ -4,14 +4,18 @@ import info.mmpa.pipeblocker.PipeBlocker;
 import sun.misc.ObjectInputFilter;
 
 public class FilterSetter {
+    private static boolean applied = false;
     public static void apply() {
-        ObjectInputFilter.Config.setSerialFilter(filterInfo -> {
-            switch (PipeBlocker.check(filterInfo.serialClass())) {
-                case UNDECIDED: return sun.misc.ObjectInputFilter.Status.UNDECIDED;
-                case ALLOWED: return sun.misc.ObjectInputFilter.Status.ALLOWED;
-                case REJECTED: return sun.misc.ObjectInputFilter.Status.REJECTED;
-            }
-            throw new AssertionError("unknown check status");
-        });
+        if (!applied) {
+            ObjectInputFilter.Config.setSerialFilter(filterInfo -> {
+                switch (PipeBlocker.check(filterInfo.serialClass())) {
+                case UNDECIDED: return ObjectInputFilter.Status.UNDECIDED;
+                case ALLOWED: return ObjectInputFilter.Status.ALLOWED;
+                case REJECTED: return ObjectInputFilter.Status.REJECTED;
+                }
+                throw new AssertionError("unknown check status");
+            });
+            applied = true;
+        }
     }
 }

--- a/common/src/main/java/info/mmpa/pipeblocker/logger/PipeBlockerJavaLogger.java
+++ b/common/src/main/java/info/mmpa/pipeblocker/logger/PipeBlockerJavaLogger.java
@@ -1,0 +1,44 @@
+package info.mmpa.pipeblocker.logger;
+
+import java.lang.reflect.Method;
+import java.util.logging.Logger;
+
+public class PipeBlockerJavaLogger implements PipeBlockerLogger {
+    private final Logger logger = Logger.getLogger("PipeBlocker");
+
+    public PipeBlockerJavaLogger() {
+        // Legacy FML logger injection
+        try {
+            Class<?> fmlLog = Class.forName("cpw.mods.fml.common.FMLLog");
+            Method getLogger = fmlLog.getMethod("getLogger");
+            getLogger.setAccessible(true);
+            logger.setParent((Logger) getLogger.invoke(null));
+        } catch (Throwable ignored) {
+        }
+    }
+
+    @Override
+    public void info(String msg) {
+        logger.info(msg);
+    }
+
+    @Override
+    public void error(String msg) {
+        logger.severe(msg);
+    }
+
+    @Override
+    public void debug(String msg) {
+        logger.finest(msg);
+    }
+
+    @Override
+    public void warn(String msg) {
+        logger.warning(msg);
+    }
+
+    @Override
+    public void fatal(String msg) {
+        logger.severe(msg);
+    }
+}

--- a/common/src/main/java/info/mmpa/pipeblocker/logger/PipeBlockerLogger.java
+++ b/common/src/main/java/info/mmpa/pipeblocker/logger/PipeBlockerLogger.java
@@ -6,4 +6,22 @@ public interface PipeBlockerLogger {
     void warn(String msg);
     void fatal(String msg);
     void error(String msg);
+
+    static PipeBlockerLogger detectLogger() {
+        try {
+            Class.forName("org.apache.logging.log4j.Logger");
+            Class.forName("org.apache.logging.log4j.LogManager");
+            return new PipeBlockerLog4jLogger();
+        } catch (ClassNotFoundException ignored) {
+        }
+
+        try {
+            Class.forName("java.util.logging.Logger");
+            return new PipeBlockerJavaLogger();
+        } catch (ClassNotFoundException ignored) {
+        }
+
+        // Should never reach here
+        return new PipeBlockerStdoutLogger();
+    }
 }

--- a/fabric/src/main/java/info/mmpa/pipeblocker/PipeBlockerInitializer.java
+++ b/fabric/src/main/java/info/mmpa/pipeblocker/PipeBlockerInitializer.java
@@ -5,7 +5,7 @@ import net.fabricmc.loader.api.entrypoint.PreLaunchEntrypoint;
 public class PipeBlockerInitializer implements PreLaunchEntrypoint {
     @Override
     public void onPreLaunch() {
-        PipeBlocker.useLog4j();
+        PipeBlocker.chooseBestLogger();
         PipeBlocker.apply();
     }
 }

--- a/forge17_112/src/main/java/info/mmpa/pipeblocker/PipeBlockerMod.java
+++ b/forge17_112/src/main/java/info/mmpa/pipeblocker/PipeBlockerMod.java
@@ -1,20 +1,17 @@
 package info.mmpa.pipeblocker;
 
+import info.mmpa.pipeblocker.logger.PipeBlockerLogger;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.event.FMLInitializationEvent;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
-import java.util.*;
 
 @Mod(modid = "pipeblocker", name = "PipeBlocker", version = Tags.VERSION, acceptableRemoteVersions = "*")
 public class PipeBlockerMod {
 
-    public static final Logger LOGGER = LogManager.getLogger("PipeBlocker");
+    public static final PipeBlockerLogger LOGGER = PipeBlockerLogger.detectLogger();
 
     @Mod.EventHandler
     @SuppressWarnings("unused")
     public void init(FMLInitializationEvent ev) {
-        PipeBlocker.useLog4j();
+        PipeBlocker.chooseBestLogger();
     }
 }

--- a/java9/src/main/java/info/mmpa/pipeblocker/java9/FilterSetter.java
+++ b/java9/src/main/java/info/mmpa/pipeblocker/java9/FilterSetter.java
@@ -5,14 +5,18 @@ import java.io.ObjectInputFilter;
 import info.mmpa.pipeblocker.PipeBlocker;
 
 public class FilterSetter {
-    public static void apply () {
-        ObjectInputFilter.Config.setSerialFilter(filterInfo -> {
-            switch (PipeBlocker.check(filterInfo.serialClass())) {
+    private static boolean applied = false;
+    public static void apply() {
+        if (!applied) {
+            ObjectInputFilter.Config.setSerialFilter(filterInfo -> {
+                switch (PipeBlocker.check(filterInfo.serialClass())) {
                 case UNDECIDED: return ObjectInputFilter.Status.UNDECIDED;
                 case ALLOWED: return ObjectInputFilter.Status.ALLOWED;
                 case REJECTED: return ObjectInputFilter.Status.REJECTED;
-            }
-            throw new AssertionError("unknown check status");
-        });
+                }
+                throw new AssertionError("unknown check status");
+            });
+            applied = true;
+        }
     }
 }

--- a/javaagent/src/main/java/info/mmpa/pipeblocker/PipeBlockerAgent.java
+++ b/javaagent/src/main/java/info/mmpa/pipeblocker/PipeBlockerAgent.java
@@ -1,11 +1,10 @@
 package info.mmpa.pipeblocker;
 
-import org.apache.logging.log4j.*;
-
 import java.lang.instrument.*;
 
 public class PipeBlockerAgent {
     public static void premain(String args, Instrumentation instrumentation){
+        PipeBlocker.chooseBestLogger();
         PipeBlocker.apply();
         System.out.println("PipeBlocker Java agent loaded.");
     }


### PR DESCRIPTION
This is related to #10, but only fixes a few issues.
The biggest issue still standing is that Forge expects every class file to be compatible with Java 7.
However, since the mod is compiled with Java 8 (and some files even with Java 9), it shows a few errors, even though everything still works fine.
The java agent version has been successfully tested with many old Minecraft versions and it works without any problems.
